### PR TITLE
Update helm repo reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Reactive Sandbox is installed using [helm](https://helm.sh/). To do this, follow
 ```bash
 # Install Helm and add the Lightbend repository
 helm init
-helm repo add lightbend-helm-charts https://lightbend.github.io/helm-charts
+helm repo add lightbend-helm-charts https://repo.lightbend.com/helm-charts
 helm update
 
 # Install the reactive-sandbox


### PR DESCRIPTION
The default location for the Lightbend helm-charts repo has moved to https://repo.lightbend.com/helm-charts and the old location (https://lightbend.github.io/helm-charts) is deprecated (and may go away at some point). This change updates the reference in the README.